### PR TITLE
ember-cli-update init -b libkit

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,6 +1,7 @@
 .ember-cli
 DEBUG
 *.tgz
+config
 dist/**/test
 dist/**/node_modules
 ember-cli-build.js

--- a/packages/core/config/ember-cli-update.json
+++ b/packages/core/config/ember-cli-update.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 0,
+  "packages": [
+    {
+      "name": "libkit",
+      "version": "0.7.0",
+      "blueprints": [
+        {
+          "name": "libkit",
+          "isBaseBlueprint": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/core/ember-cli-build.js
+++ b/packages/core/ember-cli-build.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-module.exports = require("libkit").build({
-  name: "@cross-check/core",
+module.exports = require('libkit').build({
+  name: '@cross-check/core',
   root: __dirname
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "ember-addon"
   ],
   "scripts": {
+    "start": "ember s -p 0",
     "problems": "node ../../scripts/problems.js",
     "preversion": "\"$npm_execpath\" run test",
     "prepare": "ember build -prod",

--- a/packages/core/testem.js
+++ b/packages/core/testem.js
@@ -1,17 +1,17 @@
 module.exports = {
-  launchers: {
-    Node: {
-      cwd: process.env.EMBER_CLI_TEST_OUTPUT,
-      command: `qunit "commonjs/test/**/*-test.js"`,
-      protocol: "tap"
-    }
+  "launchers": {
+    "Node": {
+      "cwd": process.env.EMBER_CLI_TEST_OUTPUT,
+      "command": `qunit "commonjs/test/**/*-test.js"`,
+      "protocol": "tap"
+    },
   },
 
-  framework: "qunit",
-  test_page: "index.testem.html?hidepassed",
+  "framework": "qunit",
+  "test_page": "index.testem.html?hidepassed",
 
-  browser_args: {
-    Chrome: [
+  "browser_args": {
+    "Chrome": [
       "--headless",
       "--disable-gpu",
       "--no-sandbox",
@@ -20,7 +20,7 @@ module.exports = {
     ]
   },
 
-  disable_watching: true,
-  launch_in_ci: ["Node", "Chrome"],
-  launch_in_dev: ["Node", "Chrome"]
-};
+  "disable_watching": true,
+  "launch_in_dev": ["Node", "Chrome"],
+  "launch_in_ci": ["Node", "Chrome"]
+}

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -3,16 +3,13 @@
     /* Used by all targets */
 
     /* Basic Options */
-    "target":
-      "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": [
-      "es2015"
-    ] /* Specify library files to be included in the compilation */,
+    "lib": ["es2015"],                        /* Specify library files to be included in the compilation */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "stripInternal": true,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
@@ -24,28 +21,25 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
+    "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
-    "paths": {
-      "@cross-check/core": ["src/index.ts"]
-    },
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution":
-      "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
-    "rootDirs": [
-      /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "@cross-check/core": ["src/index.ts"]
+    },
+    "rootDirs": [                             /* List of root folders whose combined content represents the structure of the project at runtime. */
       "src",
       "test"
     ],
@@ -55,16 +49,18 @@
 
     /* Source Map Options */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    "sourceRoot":
-      "./" /* Specify the location where debugger should locate TypeScript files instead of source locations. */,
+    "sourceRoot": "./",                       /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
+    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
+    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */
+    "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
 
-  "include": ["src", "test"]
+  "include": [
+    "src",
+    "test"
+  ]
 }

--- a/packages/dsl/.npmignore
+++ b/packages/dsl/.npmignore
@@ -1,6 +1,7 @@
 .ember-cli
 DEBUG
 *.tgz
+config
 dist/**/test
 dist/**/node_modules
 ember-cli-build.js

--- a/packages/dsl/config/ember-cli-update.json
+++ b/packages/dsl/config/ember-cli-update.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 0,
+  "packages": [
+    {
+      "name": "libkit",
+      "version": "0.7.0",
+      "blueprints": [
+        {
+          "name": "libkit",
+          "isBaseBlueprint": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/dsl/ember-cli-build.js
+++ b/packages/dsl/ember-cli-build.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-module.exports = require("libkit").build({
-  name: "@cross-check/dsl",
+module.exports = require('libkit').build({
+  name: '@cross-check/dsl',
   root: __dirname
 });

--- a/packages/dsl/package.json
+++ b/packages/dsl/package.json
@@ -17,6 +17,7 @@
     "ember-addon"
   ],
   "scripts": {
+    "start": "ember s -p 0",
     "problems": "node ../../scripts/problems.js",
     "preversion": "\"$npm_execpath\" run test",
     "prepare": "ember build -prod",

--- a/packages/dsl/testem.js
+++ b/packages/dsl/testem.js
@@ -1,17 +1,17 @@
 module.exports = {
-  launchers: {
-    Node: {
-      cwd: process.env.EMBER_CLI_TEST_OUTPUT,
-      command: `qunit "commonjs/test/**/*-test.js"`,
-      protocol: "tap"
-    }
+  "launchers": {
+    "Node": {
+      "cwd": process.env.EMBER_CLI_TEST_OUTPUT,
+      "command": `qunit "commonjs/test/**/*-test.js"`,
+      "protocol": "tap"
+    },
   },
 
-  framework: "qunit",
-  test_page: "index.testem.html?hidepassed",
+  "framework": "qunit",
+  "test_page": "index.html?hidepassed",
 
-  browser_args: {
-    Chrome: [
+  "browser_args": {
+    "Chrome": [
       "--headless",
       "--no-sandbox",
       "--disable-gpu",
@@ -20,7 +20,7 @@ module.exports = {
     ]
   },
 
-  disable_watching: true,
-  launch_in_ci: ["Node", "Chrome"],
-  launch_in_dev: ["Node", "Chrome"]
-};
+  "disable_watching": true,
+  "launch_in_dev": ["Node", "Chrome"],
+  "launch_in_ci": ["Node", "Chrome"]
+}

--- a/packages/dsl/tsconfig.json
+++ b/packages/dsl/tsconfig.json
@@ -3,16 +3,13 @@
     /* Used by all targets */
 
     /* Basic Options */
-    "target":
-      "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": [
-      "es2015"
-    ] /* Specify library files to be included in the compilation */,
+    "lib": ["es2015"],                        /* Specify library files to be included in the compilation */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "stripInternal": true,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
@@ -24,28 +21,25 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
+    "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
-    "paths": {
-      "@cross-check/dsl": ["src/index.ts"]
-    },
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution":
-      "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
-    "rootDirs": [
-      /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "@cross-check/dsl": ["src/index.ts"]
+    },
+    "rootDirs": [                             /* List of root folders whose combined content represents the structure of the project at runtime. */
       "src",
       "test"
     ],
@@ -55,16 +49,18 @@
 
     /* Source Map Options */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    "sourceRoot":
-      "./" /* Specify the location where debugger should locate TypeScript files instead of source locations. */,
+    "sourceRoot": "./",                       /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    "inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
+    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
+    "inlineSources": true,                    /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */
+    "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
 
-  "include": ["src", "test"]
+  "include": [
+    "src",
+    "test"
+  ]
 }

--- a/packages/schema/.npmignore
+++ b/packages/schema/.npmignore
@@ -1,6 +1,7 @@
 .ember-cli
 DEBUG
 *.tgz
+config
 dist/**/test
 dist/**/node_modules
 ember-cli-build.js

--- a/packages/schema/config/ember-cli-update.json
+++ b/packages/schema/config/ember-cli-update.json
@@ -1,0 +1,15 @@
+{
+  "schemaVersion": 0,
+  "packages": [
+    {
+      "name": "libkit",
+      "version": "0.7.0",
+      "blueprints": [
+        {
+          "name": "libkit",
+          "isBaseBlueprint": true
+        }
+      ]
+    }
+  ]
+}

--- a/packages/schema/ember-addon.js
+++ b/packages/schema/ember-addon.js
@@ -1,19 +1,18 @@
-"use strict";
+'use strict';
 
-const path = require("path");
+const path = require('path');
 
 module.exports = {
-  name: "@cross-check/schema",
+  name: '@cross-check/schema',
 
   setupPreprocessorRegistry(type, registry) {
-    if (type === "self") {
-      this.treePaths.addon = path.resolve(__dirname, "dist", "modules", "src");
+    if (type === 'self') {
+      this.treePaths.addon = path.resolve(__dirname, 'dist', 'modules', 'src');
 
-      registry.add("js", {
-        name: "babel-with-app-settings",
-        ext: "js",
-        toTree: tree =>
-          this.project.findAddonByName("ember-cli-babel").transpileTree(tree)
+      registry.add('js', {
+        name: 'babel-with-app-settings',
+        ext: 'js',
+        toTree: tree => this.project.findAddonByName('ember-cli-babel').transpileTree(tree)
       });
     }
   }

--- a/packages/schema/ember-cli-build.js
+++ b/packages/schema/ember-cli-build.js
@@ -1,6 +1,6 @@
-"use strict";
+'use strict';
 
-module.exports = require("libkit").build({
-  name: "@cross-check/schema",
+module.exports = require('libkit').build({
+  name: '@cross-check/schema',
   root: __dirname
 });

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -17,6 +17,7 @@
     "ember-addon"
   ],
   "scripts": {
+    "start": "ember s -p 0",
     "problems": "node ../../scripts/problems.js",
     "preversion": "\"$npm_execpath\" run test",
     "prepare": "ember build -prod",

--- a/packages/schema/testem.js
+++ b/packages/schema/testem.js
@@ -1,17 +1,17 @@
 module.exports = {
-  launchers: {
-    Node: {
-      cwd: process.env.EMBER_CLI_TEST_OUTPUT,
-      command: `qunit "commonjs/test/**/*-test.js"`,
-      protocol: "tap"
-    }
+  "launchers": {
+    "Node": {
+      "cwd": process.env.EMBER_CLI_TEST_OUTPUT,
+      "command": `qunit "commonjs/test/**/*-test.js"`,
+      "protocol": "tap"
+    },
   },
 
-  framework: "qunit",
-  test_page: "index.testem.html?hidepassed",
+  "framework": "qunit",
+  "test_page": "index.testem.html?hidepassed",
 
-  browser_args: {
-    Chrome: [
+  "browser_args": {
+    "Chrome": [
       "--headless",
       "--no-sandbox",
       "--disable-gpu",
@@ -20,7 +20,7 @@ module.exports = {
     ]
   },
 
-  disable_watching: true,
-  launch_in_ci: ["Node", "Chrome"],
-  launch_in_dev: ["Node", "Chrome"]
-};
+  "disable_watching": true,
+  "launch_in_dev": ["Node", "Chrome"],
+  "launch_in_ci": ["Node", "Chrome"]
+}

--- a/packages/schema/tsconfig.json
+++ b/packages/schema/tsconfig.json
@@ -3,16 +3,13 @@
     /* Used by all targets */
 
     /* Basic Options */
-    "target":
-      "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */,
+    "target": "es2015",                       /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
     // "module": "es2015",                    /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    "lib": [
-      "es2015"
-    ] /* Specify library files to be included in the compilation */,
+    "lib": ["es2015"],                        /* Specify library files to be included in the compilation */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true /* Generates corresponding '.d.ts' file. */,
+    "declaration": true,                      /* Generates corresponding '.d.ts' file. */
     "stripInternal": true,
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
@@ -24,28 +21,25 @@
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     /* Strict Type-Checking Options */
-    "strict": true /* Enable all strict type-checking options. */,
+    "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
     // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    "noUnusedLocals": true /* Report errors on unused locals. */,
-    "noUnusedParameters": true /* Report errors on unused parameters. */,
-    "noImplicitReturns": true /* Report error when not all code paths in function return a value. */,
-    "noFallthroughCasesInSwitch": true /* Report errors for fallthrough cases in switch statement. */,
-
-    "paths": {
-      "@cross-check/schema": ["src/index.ts"]
-    },
+    "noUnusedLocals": true,                   /* Report errors on unused locals. */
+    "noUnusedParameters": true,               /* Report errors on unused parameters. */
+    "noImplicitReturns": true,                /* Report error when not all code paths in function return a value. */
+    "noFallthroughCasesInSwitch": true,       /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    "moduleResolution":
-      "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-    "baseUrl": "./" /* Base directory to resolve non-absolute module names. */,
-    "rootDirs": [
-      /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    "baseUrl": "./",                          /* Base directory to resolve non-absolute module names. */
+    "paths": {                                /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+      "@cross-check/schema": ["src/index.ts"]
+    },
+    "rootDirs": [                             /* List of root folders whose combined content represents the structure of the project at runtime. */
       "src",
       "test"
     ],
@@ -55,16 +49,18 @@
 
     /* Source Map Options */
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    "sourceRoot":
-      "./" /* Specify the location where debugger should locate TypeScript files instead of source locations. */,
+    "sourceRoot": "./",                       /* Specify the location where debugger should locate TypeScript files instead of source locations. */
     // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    "inlineSourceMap": true /* Emit a single file with source maps instead of having a separate file. */,
-    //"inlineSources": true /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */,
+    "inlineSourceMap": true,                  /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
-    "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */
+    "experimentalDecorators": true            /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
   },
 
-  "include": ["src", "test"]
+  "include": [
+    "src",
+    "test"
+  ]
 }


### PR DESCRIPTION
Similar to https://github.com/tildeio/ts-std/pull/10. This is one of the main use cases described in https://github.com/emberjs/rfcs/pull/477.

This replaces the remembering to run `ember init -b libkit` when a new version comes out, then undoing the reset just to take the bits you want.

I ran `ember-cli-update init -b libkit` just to start tracking (then took some of the updates). This doesn't have to be run again. Now you can run `ember-cli-update` and it will tell you if there's an update, and update for you if so.

cc @wycats @rwjblue